### PR TITLE
fix: bump url-parse version in cli-core (1.5.1 misses index.js)

### DIFF
--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -53,7 +53,7 @@
     "tslib": "2.3.1",
     "tunnel": "0.0.6",
     "update-notifier": "5.1.0",
-    "url-parse": "1.5.1"
+    "url-parse": "1.5.3"
   },
   "devDependencies": {
     "@types/axios": "0.14.0",


### PR DESCRIPTION
Iirc 1.5.1 is a broken release and `index.js` is missing in node_modules:
`Error: Cannot find module '.../tsed-cli/packages/cli-core/node_modules/url-parse/index.js'. Please verify that the package.json has a valid "main" entry`

In yarn.lock it seems to be locked at 1.4.7 so that might also need updating.