### PR TITLE
Add features file argument to init command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,16 +33,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [ 14.x, 15.x ]
+        node-version: [16.x]
         exclude:
-#          - os: macos-latest
-#            node-version: 12.x
-#          - os: macos-latest
-#            node-version: 15.x
-#          - os: windows-latest
-#            node-version: 12.x
+          #          - os: macos-latest
+          #            node-version: 12.x
+          #          - os: macos-latest
+          #            node-version: 15.x
+          #          - os: windows-latest
+          #            node-version: 12.x
           - os: windows-latest
-            node-version: 15.x
+            node-version: 16.x
 
     steps:
       - uses: actions/checkout@v2
@@ -54,29 +54,29 @@ jobs:
         run: yarn install --frozen-lockfile --network-timeout 500000
       - name: Run test
         run: yarn test:coverage
-#      - name: Coveralls
-#        uses: coverallsapp/github-action@master
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          flag-name: run-${{ matrix.test_number }}
-#          parallel: true
+  #      - name: Coveralls
+  #        uses: coverallsapp/github-action@master
+  #        with:
+  #          github-token: ${{ secrets.GITHUB_TOKEN }}
+  #          flag-name: run-${{ matrix.test_number }}
+  #          parallel: true
 
-#  coveralls:
-#    needs: test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Coveralls Finished
-#        uses: coverallsapp/github-action@master
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          parallel-finished: true
+  #  coveralls:
+  #    needs: test
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #      - name: Coveralls Finished
+  #        uses: coverallsapp/github-action@master
+  #        with:
+  #          github-token: ${{ secrets.GITHUB_TOKEN }}
+  #          parallel-finished: true
 
   build:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -96,7 +96,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -126,7 +126,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/cli-core/src/interfaces/CommandProvider.ts
+++ b/packages/cli-core/src/interfaces/CommandProvider.ts
@@ -5,6 +5,12 @@ export type QuestionOptions<T = any> = Inquirer.QuestionCollection<T>;
 
 export interface CommandProvider<Ctx = any> {
   /**
+   * Run a function before the main prompt. Useful for pre-loading data from the file system
+   * @param initialOptions
+   */
+  $beforePrompt?(initialOptions: Partial<Ctx>): Partial<Ctx>;
+
+  /**
    * Hook to create the main prompt for the command
    * See https://github.com/enquirer/enquirer for more detail on question configuration.
    * @param initialOptions

--- a/packages/cli-core/src/services/CliPlugins.ts
+++ b/packages/cli-core/src/services/CliPlugins.ts
@@ -70,6 +70,6 @@ export class CliPlugins {
   }
 
   private isPlugin(name: any) {
-    return name.startsWith(`@${this.name}/cli-plugin`) || name.startsWith(`${this.name}-cli-plugin`);
+    return name.startsWith(`@${this.name}/cli-plugin`) || name.includes(`${this.name}-cli-plugin`);
   }
 }

--- a/packages/cli-core/src/services/CliService.ts
+++ b/packages/cli-core/src/services/CliService.ts
@@ -80,6 +80,7 @@ export class CliService {
    * @param data
    */
   public async runLifecycle(cmdName: string, data: any = {}) {
+    data = await this.beforePrompt(cmdName, data);
     data = await this.prompt(cmdName, data);
 
     try {
@@ -110,6 +111,23 @@ export class CliService {
 
       return createTasksRunner(tasks, this.mapContext(cmdName, ctx));
     }
+  }
+
+  /**
+   * Run prompt for a given command
+   * @param cmdName
+   * @param ctx Initial data
+   */
+  public async beforePrompt(cmdName: string, ctx: any = {}) {
+    const provider = this.commands.get(cmdName);
+    const instance = this.injector.get<CommandProvider>(provider.useClass)!;
+    const verbose = ctx.verbose;
+
+    if (instance.$beforePrompt) {
+      ctx = await instance.$beforePrompt(JSON.parse(JSON.stringify(ctx)));
+      ctx.verbose = verbose;
+    }
+    return ctx;
   }
 
   /**

--- a/packages/cli-core/src/utils/loadPlugins.ts
+++ b/packages/cli-core/src/utils/loadPlugins.ts
@@ -14,7 +14,7 @@ export async function loadPlugins(injector: InjectorService) {
   const fs = injector.invoke<CliFs>(CliFs);
 
   const promises = Object.keys(projectPackageJson.allDependencies)
-    .filter((mod) => mod.startsWith(`@${name}/cli-plugin`) || mod.startsWith(`${name}-cli-plugin`))
+    .filter((mod) => mod.startsWith(`@${name}/cli-plugin`) || mod.includes(`${name}-cli-plugin`))
     .map(async (mod) => {
       const {default: plugin} = await fs.importModule(mod, rootDir);
 

--- a/packages/cli/src/commands/init/InitCmd.ts
+++ b/packages/cli/src/commands/init/InitCmd.ts
@@ -16,12 +16,12 @@ import {
   RootRendererService
 } from "@tsed/cli-core";
 import {camelCase, paramCase, pascalCase} from "change-case";
-import {basename, join} from "path";
+import {basename, join, resolve} from "path";
 import {DEFAULT_TSED_TAGS} from "../../constants";
 import {ArchitectureConvention} from "../../interfaces/ArchitectureConvention";
 import {ProjectConvention} from "../../interfaces/ProjectConvention";
 import {OutputFilePathPipe} from "../../pipes/OutputFilePathPipe";
-import {Features, FeatureValue} from "../../services/Features";
+import {Features, FeatureValue, parseFeaturesFile} from "../../services/Features";
 
 export interface InitCmdContext extends CliDefaultOptions, InstallOptions {
   platform: "express" | "koa";
@@ -56,6 +56,10 @@ export interface InitCmdContext extends CliDefaultOptions, InstallOptions {
       type: String,
       defaultValue: DEFAULT_TSED_TAGS,
       description: "Use a specific version of Ts.ED (format: 5.x.x)"
+    },
+    "-f, --features-file <path>": {
+      type: String,
+      description: "Location of a file in which the features are defined."
     }
   }
 })
@@ -84,7 +88,19 @@ export class InitCmd implements CommandProvider {
   @Inject()
   protected fs: CliFs;
 
+  async $beforePrompt(initialOptions: Partial<InitCmdContext>) {
+    const callPath = process.cwd();
+    if (callPath && initialOptions.featuresFile) {
+      const featuresFilePath = resolve(callPath, initialOptions.featuresFile);
+      const featuresFromFile = await import(featuresFilePath);
+      const mappedFeatures = parseFeaturesFile(featuresFromFile, "3.8.0"); // Inject CLI version
+      initialOptions = {...initialOptions, ...mappedFeatures};
+    }
+    return initialOptions;
+  }
+
   $prompt(initialOptions: Partial<InitCmdContext>): QuestionOptions {
+    const featuresQuestions = initialOptions.features?.length ? [] : [...this.features];
     return [
       {
         type: "input",
@@ -96,7 +112,7 @@ export class InitCmd implements CommandProvider {
           return paramCase(input);
         }
       },
-      ...this.features
+      ...featuresQuestions
     ];
   }
 
@@ -106,7 +122,7 @@ export class InitCmd implements CommandProvider {
     const features: FeatureValue[] = [];
 
     Object.entries(ctx)
-      .filter(([key]) => key.startsWith("features"))
+      .filter(([key]) => key.startsWith("features") && key !== "featuresFile")
       .forEach(([key, value]: any[]) => {
         delete ctx[key];
         features.push(...[].concat(value));


### PR DESCRIPTION
This PR adds the ability to provide a features file as an argument to the CLI in order to skip the prompts. Some advantages:
- When developing/testing CLI init commands you do not have to repeat the same prompts every time.
- The website could provide a generator for a features file (i.e. select the features you want and the corresponding file will be created).
- Third-party plugins can be added upon initialization.

The following changes were required:
- Added a `$beforePrompt` hook
- Loading plugins looks for packages which include `tsed-cli-plugin` instead of starting with it (to enable @thirdparty/tsed-cli-plugin-xyz).
- Added a --features-file (-f) argument to InitCmd
- Refactored Features.ts

An example of a features.json file:
```json
{
  "platform": "express", 
  "convention": "default",
  "features": [
    "graphql",    "db",
    "testing",    "linter",
    "commands",
    {
      "type": "oidc",
      "devDependencies": {
        "@tsed/cli-plugin-oidc-provider": "latest"
      }
    }
  ],
  "featuresDB": "typeorm",
  "featuresTypeORM": "typeorm:sqlite",
  "featuresTesting": "jest",
  "featuresLinter": "eslint",
  "featuresExtraLinter": [ "prettier", "lintstaged" ],
  "packageManager": "pnpm"
}
```
To use it:
`tsed init . --features-file ./features.json`

Any suggestions for improvements are welcome :smile: .