### PR TITLE
fix(cli): made copying of yarn.lock in the dockerfile conditional

### DIFF
--- a/packages/cli/templates/init/Dockerfile.hbs
+++ b/packages/cli/templates/init/Dockerfile.hbs
@@ -19,7 +19,7 @@ ARG NODE_VERSION=16.13.1
 FROM node:${NODE_VERSION}-alpine as build
 WORKDIR /opt
 
-COPY package.json yarn.lock tsconfig.json tsconfig.compile.json .barrelsby.json ./
+COPY package.json {{#if yarn}}yarn.lock {{/if}}tsconfig.json tsconfig.compile.json .barrelsby.json ./
 
 RUN yarn install --pure-lockfile
 {{#if yarn}}

--- a/packages/cli/templates/init/Dockerfile.hbs
+++ b/packages/cli/templates/init/Dockerfile.hbs
@@ -21,7 +21,6 @@ WORKDIR /opt
 
 COPY package.json {{#if yarn}}yarn.lock {{/if}}tsconfig.json tsconfig.compile.json .barrelsby.json ./
 
-RUN yarn install --pure-lockfile
 {{#if yarn}}
 RUN yarn install --pure-lockfile{{/if}}{{#if npm}}
 RUN npm install{{/if}}{{#if pnpm}}


### PR DESCRIPTION
Addressing issue #282.  
Additionally: Removed line `RUN yarn install --pure-lockfile` from the dockerfile to avoid merge conflicts with #321 