### PR TITLE
fix: Use --enable-source-maps flag in nodemon.json to show correct line number in stack trace

### DIFF
--- a/packages/cli/templates/init/nodemon.json.hbs
+++ b/packages/cli/templates/init/nodemon.json.hbs
@@ -4,6 +4,6 @@
   "ignore": ["**/*.spec.ts"],
   "delay": 100,
   "execMap": {
-    "ts": "node --import @swc-node/register/esm-register"
+    "ts": "node --enable-source-maps --import @swc-node/register/esm-register"
   }
 }


### PR DESCRIPTION
Using a simple example like:
```typescript
import { join } from "node:path";
import { Configuration } from "@tsed/di";
import { application } from "@tsed/platform-http";
import "@tsed/platform-log-request"; // remove this import if you don&#x27;t want log request
import "@tsed/platform-express"; // /!\ keep this import
import "@tsed/ajv";
import { config } from "./config/index.js";
import * as rest from "./controllers/rest/index.js";

@Configuration({
  ...config,
  acceptMimes: ["application/json"],
  httpPort: process.env.PORT || 8083,
  httpsPort: false, // CHANGE
  disableComponentsScan: true,
  ajv: {
    returnsCoercedValues: true
  },
  mount: {
    "/rest": [
      ...Object.values(rest)
    ]
  },
  middlewares: [
    "cors",
    "cookie-parser",
    "compression",
    "method-override",
    "json-parser",
    { use: "urlencoded-parser", options: { extended: true } }
  ],
  views: {
    root: join(process.cwd(), "../views"),
    extensions: {
      ejs: "ejs"
    }
  },
  exclude: [
    "**/*.spec.ts"
  ]
})
export class Server {
  protected app = application();

  public $onReady() {
    throw Error("Oh no");
  }
}
```

The current stack trace contains the line numbers of the transpile file but points to the ts file.
E.g. here it is line 12 but that's the `acceptMimes` line

```bash
[2025-02-19T10:13:58.006] [ERROR] [TSED] - {
  event: 'SERVER_BOOTSTRAP_ERROR',
  message: 'Oh no',
  stack: 'Error: Oh no\n' +
    '    at Server.$onReady (file:///home/thanatos/projects/tsed-example/src/Server.ts:12:15)\n' +
    '    at listener (file:///home/thanatos/projects/tsed-example/node_modules/@tsed/di/lib/esm/common/utils/discoverHooks.js:5:76)\n' +
    '    at callback (file:///home/thanatos/projects/tsed-example/node_modules/@tsed/di/lib/esm/common/services/InjectorService.js:472:28)\n' +
    '    at file:///home/thanatos/projects/tsed-example/node_modules/@tsed/hooks/lib/esm/Hooks.js:83:93\n' +
    '    at Array.map (<anonymous>)\n' +
    '    at Hooks.asyncEmit (file:///home/thanatos/projects/tsed-example/node_modules/@tsed/hooks/lib/esm/Hooks.js:83:71)\n' +
    '    at PlatformBuilder.callHook (file:///home/thanatos/projects/tsed-example/node_modules/@tsed/platform-http/lib/esm/common/builder/PlatformBuilder.js:208:15)\n' +
    '    at PlatformBuilder.ready (file:///home/thanatos/projects/tsed-example/node_modules/@tsed/platform-http/lib/esm/common/builder/PlatformBuilder.js:198:20)\n' +
    '    at PlatformBuilder.listen (file:///home/thanatos/projects/tsed-example/node_modules/@tsed/platform-http/lib/esm/common/builder/PlatformBuilder.js:189:20)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)'
}
```

Using `--enable-source-maps` flags points to the correct line number (which is the `throw Error...` one).

It also points e.g. to the `Hook.ts` file now instead of the `Hook.js` file but that shouldn't be an issue?

```bash
[2025-02-19T10:14:42.723] [ERROR] [TSED] - {
  event: 'SERVER_BOOTSTRAP_ERROR',
  message: 'Oh no',
  stack: 'Error: Oh no\n' +
    '    at $onReady (/home/thanatos/projects/tsed-example/src/Server.ts:46:11)\n' +
    '    at listener (/home/thanatos/projects/tsed-example/node_modules/@tsed/di/src/common/utils/discoverHooks.ts:6:82)\n' +
    '    at callback (/home/thanatos/projects/tsed-example/node_modules/@tsed/di/src/common/services/InjectorService.ts:570:18)\n' +
    '    at <anonymous> (/home/thanatos/projects/tsed-example/node_modules/@tsed/hooks/src/Hooks.ts:180:87)\n' +
    '    at Array.map (<anonymous>)\n' +
    '    at Hooks.asyncEmit (/home/thanatos/projects/tsed-example/node_modules/@tsed/hooks/src/Hooks.ts:180:65)\n' +
    '    at PlatformBuilder.callHook (/home/thanatos/projects/tsed-example/node_modules/@tsed/platform-http/src/common/builder/PlatformBuilder.ts:290:11)\n' +
    '    at PlatformBuilder.ready (/home/thanatos/projects/tsed-example/node_modules/@tsed/platform-http/src/common/builder/PlatformBuilder.ts:276:16)\n' +
    '    at PlatformBuilder.listen (/home/thanatos/projects/tsed-example/node_modules/@tsed/platform-http/src/common/builder/PlatformBuilder.ts:263:16)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)'
}
```

If this is fine, eventually the migrate page shoudl reflect this in the `nodemon.json` example:
https://tsed.dev/introduction/migrate-from-v7.html