### PR TITLE
fix(cli-mcp): remove missing package binary declarations

### DIFF
--- a/packages/cli-mcp/package.json
+++ b/packages/cli-mcp/package.json
@@ -21,14 +21,7 @@
     "test": "vitest run",
     "test:ci": "vitest run --coverage.thresholds.autoUpdate=true"
   },
-  "bin": {
-    "tsed": "lib/esm/bin/tsed.js",
-    "tsed-mcp": "lib/esm/bin/tsed-mcp.js"
-  },
   "files": [
-    "lib/esm/bin/tsed.js",
-    "lib/esm/bin/tsed-mcp.js",
-    "lib/esm/bin",
     "lib",
     "templates"
   ],


### PR DESCRIPTION
Fixes tsedio/tsed-cli#568.

`@tsed/cli-mcp` currently declares `tsed` and `tsed-mcp` binaries that are not emitted by this workspace package. A clean published install therefore wires commands to files that are not present. The actual Ts.ED CLI binary lives in `@tsed/cli`, where the `mcp` command starts the MCP server.

This removes the stale `bin` declarations and the matching explicit `files` entries from `packages/cli-mcp/package.json`, so the support library package no longer publishes broken executable metadata.

Validation performed:
- `corepack yarn workspace @tsed/cli-mcp build:ts`
- `npm pack --dry-run --json` from `packages/cli-mcp` and confirmed the tarball has no missing `lib/esm/bin/*` entries.
- `git diff --check`
